### PR TITLE
Events Simplification

### DIFF
--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -5,5 +5,4 @@ version = "0.1.0"
 authors = ["Romain Vaillant <rph.vaillant@gmail.com>"]
 
 [dependencies]
-mopa = "0.2"
 crossbeam = "0.2"

--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -1,105 +1,65 @@
-#[macro_use]
-extern crate mopa;
 extern crate crossbeam;
 
-use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use std::any::Any;
+use std::sync::Arc;
 use crossbeam::sync::SegQueue;
-use std::sync::{RwLock, Arc, Weak};
 
-trait AnyShared: mopa::Any + Sync + Send {}
-impl<T: mopa::Any + Sync + Send> AnyShared for T {}
+pub trait Message: Any + Sync + Send {}
 
-mopafy!(AnyShared);
-
-pub trait Event: Send + Sync + Clone + Any {}
-
-type Sender<E> = Weak<SegQueue<E>>;
-type Senders<E> = Vec<Sender<E>>;
-
-type Receiver<E> = Arc<SegQueue<E>>;
-
-pub struct EventDispatcher {
-    senders: RwLock<HashMap<TypeId, Box<AnyShared>>>
+struct MessageBuffer<M: Message> {
+    buffer: SegQueue<M>,
 }
 
-impl EventDispatcher {
+impl<M: Message> MessageBuffer<M> {
     pub fn new() -> Self {
-        EventDispatcher {
-            senders: RwLock::new(HashMap::new())
-        }
+        MessageBuffer { buffer: SegQueue::new() }
     }
 
-    pub fn dispatch<E: Event>(&self, event: E) {
-        let dropped_senders = self.send_to_all::<E>(event);
-        self.clear_dropped::<E>(&dropped_senders);
+    #[inline]
+    pub fn append(&self, message: M) {
+        self.buffer.push(message)
     }
 
-    fn send_to_all<E: Event>(&self, event: E) -> Vec<usize> {
-        let senders = self.senders.read().unwrap();
-        let mut dropped_senders = Vec::new();
-
-        if let Some(event_senders) = senders.get(&TypeId::of::<Senders<E>>()) {
-            let event_senders = event_senders.downcast_ref::<Senders<E>>().unwrap();
-
-            for (index, event_sender) in event_senders.iter().enumerate() {
-                match event_sender.upgrade() {
-                    Some(sender) => sender.push(event.clone()),
-                    None => dropped_senders.push(index),
-                }
-            }
-        }
-
-        dropped_senders
-    }
-
-    fn clear_dropped<E: Event>(&self, dropped_senders: &[usize]) {
-        if dropped_senders.len() == 0 { return; }
-
-        let mut senders = self.senders.write().unwrap();
-
-        if let Some(event_senders) = senders.get_mut(&TypeId::of::<Senders<E>>()) {
-            let event_senders = event_senders.downcast_mut::<Senders<E>>().unwrap();
-
-            for &dropped in dropped_senders {
-                event_senders.swap_remove(dropped);
-            }
-        }
-    }
-
-    fn register<E: Event>(&self, sender: Sender<E>) {
-        let mut senders = self.senders.write().unwrap();
-
-        let event_senders = senders.entry(TypeId::of::<Senders<E>>())
-            .or_insert(Box::new(Vec::<Sender<E>>::new()));
-
-        let event_senders = event_senders.downcast_mut::<Senders<E>>().unwrap();
-        event_senders.push(sender);
-    }
-
-    pub fn listen_to<E: Event>(&self) -> EventReceiver<E> {
-        let queue = Arc::new(SegQueue::new());
-
-        let sender = Arc::downgrade(&queue);
-        self.register::<E>(sender);
-        
-        EventReceiver {
-            receiver: queue
-        }
+    #[inline]
+    pub fn next(&self) -> Option<M> {
+        self.buffer.try_pop()
     }
 }
 
+pub struct MessageBox<M: Message>(Arc<MessageBuffer<M>>);
 
-pub struct EventReceiver<E: Event> {
-    receiver: Receiver<E>
+
+impl<M: Message> MessageBox<M> {
+    pub fn new() -> Self {
+        MessageBox(Arc::new(MessageBuffer::new()))
+    }
+
+    pub fn sender(&self) -> MessageSender<M> {
+        MessageSender(self.0.clone())
+    }
+
+    pub fn drain(&self) -> DrainIter<M> {
+        DrainIter { inner: &*self.0 }
+    }
 }
 
-impl<E: Event> EventReceiver<E> {
-    pub fn handle_with<F>(&mut self, mut handler: F)
-        where F: FnMut(&E) 
-    {
-        while let Some(event) = self.receiver.try_pop() {
-            handler(&event)
-        }
+pub struct MessageSender<M: Message>(Arc<MessageBuffer<M>>);
+
+impl<M: Message> MessageBox<M> {
+    #[inline]
+    pub fn send(&self, message: M) {
+        self.0.append(message);
+    }
+}
+
+pub struct DrainIter<'a, M: Message> {
+    inner: &'a MessageBuffer<M>,
+}
+
+impl<'a, M: Message> Iterator for DrainIter<'a, M> {
+    type Item = M;
+
+    fn next(&mut self) -> Option<M> {
+        self.inner.next()
     }
 }

--- a/inputs/Cargo.toml
+++ b/inputs/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Thomas Koehler <basta.t.k+git@gmail.com>"]
 glutin = "0.6"
 cgmath = "0.11"
 yaml-rust = "0.3"
+error-chain = "0.8"
 
 [dev_dependencies]
 lazybox_frameclock = { path = "../frameclock" }

--- a/inputs/Cargo.toml
+++ b/inputs/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 authors = ["Thomas Koehler <basta.t.k+git@gmail.com>"]
 
 [dependencies]
-lazybox_events = { path = "../events" }
 glutin = "0.6"
 cgmath = "0.11"
 yaml-rust = "0.3"

--- a/inputs/examples/simple.rs
+++ b/inputs/examples/simple.rs
@@ -6,11 +6,10 @@ use inputs::Inputs;
 use frameclock::FrameClock;
 use glutin::Window;
 
-inputs_interaction! {
-    "spaceship" => ActionIterator, Action { 
-        Shoot => "Shoot", 
-        LaunchBomb => "LaunchBomb",
-    }
+use self::spaceship::{Action, ActionIterator};
+
+input_interfaces! {
+    spaceship => { Shoot, LaunchBomb, }
 }
 
 pub struct ActionListener;

--- a/inputs/examples/simple.rs
+++ b/inputs/examples/simple.rs
@@ -30,9 +30,10 @@ impl ActionListener {
 
 fn main() {
     let mut inputs = Inputs::new(build_interaction());
-    inputs.load_interaction_profile("interaction/profile.yml");
 
-    let mut action_listener = ActionListener;
+    inputs.load_interaction_profile("interaction/profile.yml").unwrap();
+
+    let action_listener = ActionListener;
 
     let window = Window::new().unwrap();
 

--- a/inputs/examples/simple.rs
+++ b/inputs/examples/simple.rs
@@ -51,7 +51,7 @@ fn main() {
         }
 
         for _ in frameclock.drain_updates() {
-            inputs.update_state_actions();
+            inputs.trigger_state_actions();
             action_listener.process(&inputs);
             inputs.clear_actions();
         }

--- a/inputs/src/error.rs
+++ b/inputs/src/error.rs
@@ -1,0 +1,16 @@
+error_chain! {
+    types {}
+    links {}
+
+    foreign_links {
+        Io(::std::io::Error);
+        Yaml(::yaml_rust::ScanError);
+    }
+
+    errors {
+        RulesFormat
+        InterfaceFormat
+        ConditionFormat
+        UnknownInterface
+    }
+}

--- a/inputs/src/interaction.rs
+++ b/inputs/src/interaction.rs
@@ -137,18 +137,18 @@ impl Interaction {
         self.interfaces.get(name)
     }
 
-    pub(crate) fn acknowledge_input_actions(&mut self, input: &Input, state: &InputState)
+    pub(crate) fn trigger_input_actions(&mut self, input: &Input, state: &InputState)
     {
         // TODO: enable/disable interface dispatch
         for (_, interface) in &mut self.interfaces {
-            interface.acknowledge_input_actions(input, state);
+            interface.trigger_input_actions(input, state);
         }
     }
 
-    pub(crate) fn update_state_actions(&mut self, state: &InputState) {
+    pub(crate) fn trigger_state_actions(&mut self, state: &InputState) {
         // TODO: enable/disable interface dispatch
         for (_, interface) in &mut self.interfaces {
-            interface.update_state_actions(state);
+            interface.trigger_state_actions(state);
         }
     }
 
@@ -203,7 +203,7 @@ impl Interface {
         Ok(())
     }
 
-    fn acknowledge_input_actions(&mut self, input: &Input,
+    fn trigger_input_actions(&mut self, input: &Input,
                                      _state: &InputState)
     {
         if let Some(action) = self.rules.by_input.get(input) {
@@ -211,7 +211,7 @@ impl Interface {
         }
     }
 
-    fn update_state_actions(&mut self, state: &InputState) {
+    fn trigger_state_actions(&mut self, state: &InputState) {
         for ca in &self.rules.others {
             if let Some(action) = ca.may_trigger(state) {
                self.triggered_actions.push(action);

--- a/inputs/src/interaction.rs
+++ b/inputs/src/interaction.rs
@@ -87,7 +87,7 @@ pub struct InterfaceBuilder {
 }
 
 impl InterfaceBuilder {
-    pub fn new<E: ActionEvent>() -> Self {
+    pub fn new() -> Self {
         InterfaceBuilder {
             actions: HashSet::new(),
         }
@@ -107,10 +107,6 @@ impl InterfaceBuilder {
     }
 }
 
-pub trait ActionEvent {
-    fn dispatch(action: &'static str);
-}
-
 pub struct Interaction {
     interfaces: HashMap<&'static str, Interface>,
 }
@@ -124,6 +120,10 @@ impl Interaction {
 
             interface.load_rules(rules);
         }
+    }
+
+    pub(crate) fn interface(&self, name: &str) -> Option<&Interface> {
+        self.interfaces.get(name)
     }
 
     pub(crate) fn acknowledge_input_actions(&mut self, input: &Input, state: &InputState)
@@ -197,6 +197,10 @@ impl Interface {
                self.triggered_actions.push(action);
             }
         }
+    }
+
+    pub fn triggered_actions(&self) -> &[Action] {
+        &self.triggered_actions
     }
 
     fn clear_actions(&mut self) {

--- a/inputs/src/interaction.rs
+++ b/inputs/src/interaction.rs
@@ -66,9 +66,7 @@ pub struct InteractionBuilder {
 
 impl InteractionBuilder {
     pub fn new() -> Self {
-        InteractionBuilder {
-            interfaces: HashMap::new(),
-        }
+        InteractionBuilder { interfaces: HashMap::new() }
     }
 
     pub fn interface(mut self, name: &'static str, builder: InterfaceBuilder) -> Self {
@@ -77,9 +75,7 @@ impl InteractionBuilder {
     }
 
     pub(crate) fn build(self) -> Interaction {
-        Interaction {
-            interfaces: self.interfaces,
-        }
+        Interaction { interfaces: self.interfaces }
     }
 }
 
@@ -89,9 +85,7 @@ pub struct InterfaceBuilder {
 
 impl InterfaceBuilder {
     pub fn new() -> Self {
-        InterfaceBuilder {
-            actions: HashSet::new(),
-        }
+        InterfaceBuilder { actions: HashSet::new() }
     }
 
     pub fn action(mut self, a: Action) -> Self {
@@ -103,7 +97,7 @@ impl InterfaceBuilder {
         Interface {
             actions: self.actions,
             rules: Rules::new(),
-            triggered_actions: Vec::new()
+            triggered_actions: Vec::new(),
         }
     }
 }
@@ -130,8 +124,7 @@ impl Interaction {
         self.interfaces.get(name)
     }
 
-    pub(crate) fn trigger_input_actions(&mut self, input: &Input, state: &InputState)
-    {
+    pub(crate) fn trigger_input_actions(&mut self, input: &Input, state: &InputState) {
         // TODO: enable/disable interface dispatch
         for (_, interface) in &mut self.interfaces {
             interface.trigger_input_actions(input, state);
@@ -164,18 +157,18 @@ impl Interface {
         for rule in rules {
             let action = match rule["action"].as_str() {
                 Some(action) => action,
-                None => bail!(ErrorKind::InterfaceFormat)
+                None => bail!(ErrorKind::InterfaceFormat),
             };
 
             let when = match rule["when"].as_str() {
                 Some(when) => when,
-                None => bail!(ErrorKind::InterfaceFormat)
+                None => bail!(ErrorKind::InterfaceFormat),
             };
 
 
             if let Some(action) = self.actions.get(action) {
                 use self::WhenParse::*;
-                
+
                 match WhenParse::from_str(when) {
                     Some(Input(input)) => {
                         self.rules.by_input.insert(input, action);
@@ -196,9 +189,7 @@ impl Interface {
         Ok(())
     }
 
-    fn trigger_input_actions(&mut self, input: &Input,
-                                     _state: &InputState)
-    {
+    fn trigger_input_actions(&mut self, input: &Input, _state: &InputState) {
         if let Some(action) = self.rules.by_input.get(input) {
             self.triggered_actions.push(action);
         }
@@ -207,7 +198,7 @@ impl Interface {
     fn trigger_state_actions(&mut self, state: &InputState) {
         for ca in &self.rules.others {
             if let Some(action) = ca.may_trigger(state) {
-               self.triggered_actions.push(action);
+                self.triggered_actions.push(action);
             }
         }
     }
@@ -237,29 +228,27 @@ impl WhenParse {
         match split.next() {
             Some("Key") => {
                 split.next().and_then(|state| {
-                    split.next().and_then(|k| key_from_str(k)).and_then(|key| {
-                        match state {
-                            "Pressed" => Some(Input(Key(Pressed, key))),
-                            "Released" => Some(Input(Key(Released, key))),
-                            "Held" => Some(Condition(KeyHeld(key))),
-                            _ => None
-                        }
+                    split.next().and_then(|k| key_from_str(k)).and_then(|key| match state {
+                        "Pressed" => Some(Input(Key(Pressed, key))),
+                        "Released" => Some(Input(Key(Released, key))),
+                        "Held" => Some(Condition(KeyHeld(key))),
+                        _ => None,
                     })
                 })
             }
             Some("MouseButton") => {
                 split.next().and_then(|state| {
-                    split.next().and_then(|b| mouse_button_from_str(b)).and_then(|button| {
-                        match state {
+                    split.next()
+                        .and_then(|b| mouse_button_from_str(b))
+                        .and_then(|button| match state {
                             "Pressed" => Some(Input(MouseButton(Pressed, button))),
                             "Released" => Some(Input(MouseButton(Released, button))),
                             "Held" => Some(Condition(MouseButtonHeld(button))),
-                            _ => None
-                        }
-                    })
+                            _ => None,
+                        })
                 })
             }
-            _ => None
+            _ => None,
         }
     }
 }

--- a/inputs/src/lib.rs
+++ b/inputs/src/lib.rs
@@ -9,7 +9,8 @@ pub mod interaction;
 #[macro_use] pub mod macros;
 
 pub use state::InputState;
-pub use interaction::{Interaction, InteractionBuilder, InterfaceBuilder, ActionEvent};
+pub use interaction::{Interaction, InteractionBuilder, InterfaceBuilder, Action};
+use interaction::{Interface};
 
 use glutin::Event;
 use cgmath::Point2;
@@ -34,6 +35,11 @@ impl Inputs {
 
     pub fn interaction_mut(&mut self) -> &mut Interaction {
         &mut self.interaction
+    }
+
+    pub fn triggered_actions(&self, interface_name: &str) -> Option<&[Action]> {
+        self.interaction.interface(interface_name)
+                        .map(Interface::triggered_actions)
     }
 
     pub fn load_interaction_profile(&mut self, path: &str) {

--- a/inputs/src/lib.rs
+++ b/inputs/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(pub_restricted)]
 
-pub extern crate lazybox_events as events;
 extern crate glutin;
 extern crate cgmath;
 extern crate yaml_rust;
@@ -12,7 +11,6 @@ pub mod interaction;
 pub use state::InputState;
 pub use interaction::{Interaction, InteractionBuilder, InterfaceBuilder, ActionEvent};
 
-use events::EventDispatcher;
 use glutin::Event;
 use cgmath::Point2;
 use yaml_rust::YamlLoader;
@@ -50,15 +48,15 @@ impl Inputs {
         self.interaction.load_profile(&docs[0]);
     }
 
-    pub fn handle_event(&mut self, event: &Event, dispatcher: &EventDispatcher) {
-        let &mut Inputs { ref mut state, ref interaction } = self;
+    pub fn handle_event(&mut self, event: &Event) {
+        let &mut Inputs { ref mut state, ref mut interaction } = self;
 
         match event {
             &Event::KeyboardInput(e_state, _, Some(key)) => {
                 state.update_key(key, e_state);
 
                 let input = interaction::Input::Key(e_state, key);
-                interaction.dispatch_input_actions(&input, state, dispatcher);
+                interaction.acknowledge_input_actions(&input, state);
             }
             &Event::MouseMoved(x, y) => {
                 state.update_mouse_position(Point2::new(x, y));
@@ -67,7 +65,7 @@ impl Inputs {
                 state.update_mouse_button(button, e_state);
 
                 let input = interaction::Input::MouseButton(e_state, button);
-                interaction.dispatch_input_actions(&input, state, dispatcher);
+                interaction.acknowledge_input_actions(&input, state);
             }
             &Event::Focused(focused) => {
                 state.update_window_focus(focused);
@@ -76,9 +74,13 @@ impl Inputs {
         }
     }
 
-    pub fn dispatch_state_actions(&mut self, dispatcher: &EventDispatcher) {
-        let &mut Inputs { ref mut state, ref interaction } = self;
+    pub fn update_state_actions(&mut self) {
+        let &mut Inputs { ref mut state, ref mut interaction } = self;
         
-        interaction.dispatch_state_actions(state, dispatcher);
+        interaction.update_state_actions(state);
+    }
+
+    pub fn clear_actions(&mut self) {
+        self.interaction.clear_actions();
     }
 }

--- a/inputs/src/lib.rs
+++ b/inputs/src/lib.rs
@@ -3,44 +3,23 @@
 extern crate glutin;
 extern crate cgmath;
 extern crate yaml_rust;
+#[macro_use]
+extern crate error_chain;
 
+pub mod error;
 pub mod state;
 pub mod interaction;
 #[macro_use] pub mod macros;
 
+pub use error::{Error};
 pub use state::InputState;
-pub use interaction::{Interaction, InteractionBuilder, InterfaceBuilder, Action, ProfileError};
+pub use interaction::{Interaction, InteractionBuilder, InterfaceBuilder, Action};
 use interaction::{Interface};
+use error::Result;
 
-use std::io;
 use glutin::Event;
 use cgmath::Point2;
-use yaml_rust::{YamlLoader, ScanError};
-
-#[derive(Debug)]
-pub enum Error {
-    Io(io::Error),
-    Profile(ProfileError),
-    Yaml(ScanError)
-}
-
-impl From<ProfileError> for Error {
-    fn from(error: ProfileError) -> Self {
-        Error::Profile(error)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Self {
-        Error::Io(error)
-    }
-}
-
-impl From<ScanError> for Error {
-    fn from(error: ScanError) -> Self {
-        Error::Yaml(error)
-    }
-}
+use yaml_rust::YamlLoader;
 
 pub struct Inputs {
     state: InputState,
@@ -68,7 +47,7 @@ impl Inputs {
                         .map(Interface::triggered_actions)
     }
 
-    pub fn load_interaction_profile(&mut self, path: &str) -> Result<(), Error> {
+    pub fn load_interaction_profile(&mut self, path: &str) -> Result<()> {
         use std::fs::File;
         use std::io::prelude::*;
 

--- a/inputs/src/lib.rs
+++ b/inputs/src/lib.rs
@@ -89,7 +89,7 @@ impl Inputs {
                 state.update_key(key, e_state);
 
                 let input = interaction::Input::Key(e_state, key);
-                interaction.acknowledge_input_actions(&input, state);
+                interaction.trigger_input_actions(&input, state);
             }
             &Event::MouseMoved(x, y) => {
                 state.update_mouse_position(Point2::new(x, y));
@@ -98,7 +98,7 @@ impl Inputs {
                 state.update_mouse_button(button, e_state);
 
                 let input = interaction::Input::MouseButton(e_state, button);
-                interaction.acknowledge_input_actions(&input, state);
+                interaction.trigger_input_actions(&input, state);
             }
             &Event::Focused(focused) => {
                 state.update_window_focus(focused);
@@ -107,10 +107,10 @@ impl Inputs {
         }
     }
 
-    pub fn update_state_actions(&mut self) {
+    pub fn trigger_state_actions(&mut self) {
         let &mut Inputs { ref mut state, ref mut interaction } = self;
         
-        interaction.update_state_actions(state);
+        interaction.trigger_state_actions(state);
     }
 
     pub fn clear_actions(&mut self) {

--- a/inputs/src/lib.rs
+++ b/inputs/src/lib.rs
@@ -9,12 +9,13 @@ extern crate error_chain;
 pub mod error;
 pub mod state;
 pub mod interaction;
-#[macro_use] pub mod macros;
+#[macro_use]
+pub mod macros;
 
-pub use error::{Error};
+pub use error::Error;
 pub use state::InputState;
 pub use interaction::{Interaction, InteractionBuilder, InterfaceBuilder, Action};
-use interaction::{Interface};
+use interaction::Interface;
 use error::Result;
 
 use glutin::Event;
@@ -43,8 +44,9 @@ impl Inputs {
     }
 
     pub fn triggered_actions(&self, interface_name: &str) -> Option<&[Action]> {
-        self.interaction.interface(interface_name)
-                        .map(Interface::triggered_actions)
+        self.interaction
+            .interface(interface_name)
+            .map(Interface::triggered_actions)
     }
 
     pub fn load_interaction_profile(&mut self, path: &str) -> Result<()> {
@@ -56,7 +58,7 @@ impl Inputs {
         f.read_to_string(&mut s)?;
 
         let docs = YamlLoader::load_from_str(&s)?;
-        
+
         self.interaction.load_profile(&docs[0]).map_err(Error::from)
     }
 
@@ -88,7 +90,7 @@ impl Inputs {
 
     pub fn trigger_state_actions(&mut self) {
         let &mut Inputs { ref mut state, ref mut interaction } = self;
-        
+
         interaction.trigger_state_actions(state);
     }
 

--- a/inputs/src/macros.rs
+++ b/inputs/src/macros.rs
@@ -1,47 +1,50 @@
 #[macro_export]
-macro_rules! inputs_interaction {
-    ( $($interface:expr => $iterator:ident, $event:ident { $($variant:ident => $action:expr,)* })* ) => {
+macro_rules! input_interfaces {
+    ( $($interface:ident => { $($variant:ident,)* })* ) => {
         $(
-            #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-            pub enum $event {
-                $($variant,)*
-            }
+            pub mod $interface {
+                #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+                pub enum Action {
+                    $($variant,)*
+                }
 
-            impl<'a> From<&'a str> for $event {
-                fn from(name: &'a str) -> $event {
-                    match name {
-                        $(x if x == $action => { $event::$variant }),*
-                        _ => { panic!("event variant not handled"); }
+                impl<'a> From<&'a str> for Action {
+                    fn from(name: &'a str) -> Action {
+                        match name {
+                            $(x if x == stringify!($variant) => { Action::$variant }),*
+                            _ => { panic!("event variant not handled"); }
+                        }
+                    }
+                }
+
+                pub struct ActionIterator<'a> {
+                    inner: ::std::slice::Iter<'a, $crate::Action>,
+                }
+
+                impl<'a> ActionIterator<'a> {
+                    pub fn new(inputs: &'a $crate::Inputs) -> Option<Self> {
+                        inputs.triggered_actions(stringify!($interface))
+                            .map(|actions| ActionIterator { inner: actions.iter() })
+                    }
+                }
+
+                impl<'a> Iterator for ActionIterator<'a> {
+                    type Item = Action;
+
+                    fn next(&mut self) -> Option<Self::Item> {
+                        self.inner.next()
+                                .map(|name| Action::from(&**name))
                     }
                 }
             }
-
-            pub struct $iterator<'a> {
-                inner: ::std::slice::Iter<'a, $crate::Action>,
-            }
-
-            impl<'a> $iterator<'a> {
-                pub fn new(inputs: &'a $crate::Inputs) -> Option<Self> {
-                    inputs.triggered_actions($interface)
-                          .map(|actions| $iterator { inner: actions.iter() })
-                }
-            }
-
-            impl<'a> Iterator for $iterator<'a> {
-                type Item = $event;
-
-                fn next(&mut self) -> Option<Self::Item> {
-                    self.inner.next()
-                              .map(|name| $event::from(&**name))
-                }
-            }
+           
         )*
 
         pub fn build_interaction() -> $crate::InteractionBuilder {
             $crate::InteractionBuilder::new()
             $(
-                .interface($interface, $crate::InterfaceBuilder::new()
-                                            $(.action($action))*)
+                .interface(stringify!($interface), $crate::InterfaceBuilder::new()
+                                            $(.action(stringify!($variant)))*)
             )*
         }
     }

--- a/inputs/src/macros.rs
+++ b/inputs/src/macros.rs
@@ -1,16 +1,38 @@
 #[macro_export]
 macro_rules! inputs_interaction {
-    ( $($interface:expr => $event:ident { $($action:expr),* })* ) => {
+    ( $($interface:expr => $iterator:ident, $event:ident { $($variant:ident => $action:expr,)* })* ) => {
         $(
-            #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-            pub struct $event(pub &'static str);
+            #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+            pub enum $event {
+                $($variant,)*
+            }
 
-            impl $crate::events::Event for $event {}
+            impl<'a> From<&'a str> for $event {
+                fn from(name: &'a str) -> $event {
+                    match name {
+                        $(x if x == $action => { $event::$variant }),*
+                        _ => { panic!("event variant not handled"); }
+                    }
+                }
+            }
 
-            impl $crate::ActionEvent for $event {
-                fn dispatch(action: &'static str,
-                            dispatcher: &$crate::events::EventDispatcher) {
-                    dispatcher.dispatch($event(action));
+            pub struct $iterator<'a> {
+                inner: ::std::slice::Iter<'a, $crate::Action>,
+            }
+
+            impl<'a> $iterator<'a> {
+                pub fn new(inputs: &'a $crate::Inputs) -> Option<Self> {
+                    inputs.triggered_actions($interface)
+                          .map(|actions| $iterator { inner: actions.iter() })
+                }
+            }
+
+            impl<'a> Iterator for $iterator<'a> {
+                type Item = $event;
+
+                fn next(&mut self) -> Option<Self::Item> {
+                    self.inner.next()
+                              .map(|name| $event::from(&**name))
                 }
             }
         )*
@@ -18,7 +40,7 @@ macro_rules! inputs_interaction {
         pub fn build_interaction() -> $crate::InteractionBuilder {
             $crate::InteractionBuilder::new()
             $(
-                .interface($interface, $crate::InterfaceBuilder::new::<$event>()
+                .interface($interface, $crate::InterfaceBuilder::new()
                                             $(.action($action))*)
             )*
         }

--- a/inputs/src/state.rs
+++ b/inputs/src/state.rs
@@ -80,9 +80,7 @@ pub(crate) struct KeyboardState {
 
 impl KeyboardState {
     pub fn new() -> Self {
-        KeyboardState {
-            keys: HashSet::new(),
-        }
+        KeyboardState { keys: HashSet::new() }
     }
 }
 
@@ -92,8 +90,6 @@ pub(crate) struct WindowState {
 
 impl WindowState {
     pub fn new() -> Self {
-        WindowState {
-            focused: true,
-        }
+        WindowState { focused: true }
     }
 }


### PR DESCRIPTION
## `Event` trait and _direct_ dispatching removal

The direct dispatching has been removed to allow more flexibility to the users. Thus, permitting to take different strategies on how to provide events to other components of the application.

**Example**: The _input_ crate now enqueues actions in a simple `Vec` buffer and allows the user to get an immutable access to it when needed. With these modifications, the crate does not depend on the _event_ crate anymore.

## Messages

The _event_ crate now provides the `Message` trait and the `MessageBox` struct. A `MessageBox` is a lock-free buffer that can receive messages from multiple senders. Only the **owner** of the `MessageBox` can drain the messages and create new senders.

## Lazybox

With these simplifications, we need to provide to the user a simple way to read and process occuring events and messages. For the moment, I assumed that only the **modules** will emit _low level events_ and that the processors will only ever need to send messages to other processors or modules.

To satisfy these requirements we can take the inspiration from the `HasComponent` trait and declare the following traits:

```rust
pub trait ProduceEvent {
     type Buffer;

     fn read(&self) -> &Self::Buffer;
}

pub trait Event {
    type Producer: ProduceEvent;
}
```

**Modules** will be able to handle their message, and prepare their event buffer with a `pre_update` and `post_update` phase.

Then we could create a simple method on state to directly get an **event buffer** and read it during the processors updates.
